### PR TITLE
Update CreateBlogMetaOnDiscussionCreate.php

### DIFF
--- a/src/Listeners/CreateBlogMetaOnDiscussionCreate.php
+++ b/src/Listeners/CreateBlogMetaOnDiscussionCreate.php
@@ -20,7 +20,7 @@ class CreateBlogMetaOnDiscussionCreate
     {
         // Get Flarum settings
         $this->settings = $settings;
-        $this->blogTags = explode("|", $this->settings->get('blog_tags', []));
+        $this->blogTags = explode("|", $this->settings->get('blog_tags', ''));
     }
 
     /**


### PR DESCRIPTION
Fixes an exception people have.

Exception was thrown because you cannot explode an array. The array was the fallback for when the setting wasn't yet configured/available.