### PR TITLE
Use a more generic selector for editor textarea

### DIFF
--- a/less/Forum/Composer.less
+++ b/less/Forum/Composer.less
@@ -19,7 +19,8 @@
     display: none;
   }
 
-  .Flarum-Blog-Composer-preview, .TextEditor textarea {
+  .Flarum-Blog-Composer-preview,
+  .TextEditor-editor {
     min-height: 250px;
   }
 


### PR DESCRIPTION
Since it might not be a textarea any more, we should use the new container element's class

Closes https://github.com/v17development/flarum-blog/issues/92