### PR TITLE
fix: remove instances of `.firstPostId()`

### DIFF
--- a/js/src/forum/components/BlogPostController.js
+++ b/js/src/forum/components/BlogPostController.js
@@ -9,6 +9,7 @@ import EditPostComposer from "flarum/forum/components/EditPostComposer";
 import extractText from "flarum/common/utils/extractText";
 import ItemList from "flarum/common/utils/ItemList";
 import RenameArticleModal from "./Modals/RenameArticleModal";
+import app from "flarum/forum/app";
 
 export default class BlogPostController extends Component {
   init() {
@@ -46,9 +47,7 @@ export default class BlogPostController extends Component {
       );
     }
 
-    const articlePost = article.firstPost()
-      ? article.firstPost()
-      : app.store.getById("posts", article.firstPostId());
+    const articlePost = article.firstPost();
 
     // Edit article
     items.add(
@@ -281,9 +280,7 @@ export default class BlogPostController extends Component {
   view() {
     const article = this.attrs.article;
 
-    const articlePost = article.firstPost()
-      ? article.firstPost()
-      : app.store.getById("posts", article.firstPostId());
+    const articlePost = article.firstPost();
 
     return (
       <div className={"FlarumBlog-Article-Content-Edit-Button"}>
@@ -298,16 +295,7 @@ export default class BlogPostController extends Component {
                 // Get post data to make sure they can edit the post
                 if (articlePost && !articlePost.canEdit() && !this.loadedPost) {
                   this.loadedPost = true;
-                  app.store
-                    .find(
-                      "posts",
-                      article.firstPost()
-                        ? article.firstPost().id()
-                        : article.firstPostId()
-                    )
-                    .then(() => {})
-                    .catch(() => {})
-                    .then(() => m.redraw());
+                  m.redraw();
                 }
               },
             },

--- a/js/src/forum/pages/BlogItem.js
+++ b/js/src/forum/pages/BlogItem.js
@@ -100,9 +100,7 @@ export default class BlogItem extends Page {
     let articlePost = null;
 
     if (!this.loading && this.article) {
-      articlePost = this.article?.firstPost?.()
-        ? this.article.firstPost()
-        : app.store.getById("posts", this.article.firstPostId());
+      articlePost = this.article?.firstPost?.();
     }
 
     const items = new ItemList();


### PR DESCRIPTION
This method doesn't exist and will result in errors if run, but they are almost never run since the relationship should almost always be defined.