### PR TITLE
fix: featured count not visible in Admin dashboard

### DIFF
--- a/js/src/admin/pages/BlogSettings.js
+++ b/js/src/admin/pages/BlogSettings.js
@@ -168,7 +168,7 @@ export default class BlogSettings extends ExtensionPage {
                 </div>
                 <input
                   class="FormControl"
-                  state={this.featuredCount}
+                  value={this.featuredCount}
                   oninput={(e) => {
                     this.featuredCount = e.target.value;
                     this.hasChanges = true;


### PR DESCRIPTION
Incorrect attribute name meant the saved value would not appear in the number selection on the ACP.