### PR TITLE
Fix errors on tags page

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -39,7 +39,7 @@ app.initializers.add('v17development-flarum-blog', () => {
 
   // Add addPermissions
   extend(PermissionGrid.prototype, 'permissionItems', function (items) {
-    // Add knowledge base permissions
+    // Add blog permissions
     items.add(
       'blog',
       {

--- a/js/src/forum/pages/BlogComposer.js
+++ b/js/src/forum/pages/BlogComposer.js
@@ -256,12 +256,12 @@ export default class BlogComposer extends Page {
       return;
     }
 
-    // Find knowledge base tags
+    // Find blog tags
     const findblogTags = this.tags.filter((tag) => {
       return blogTags.indexOf(tag.id()) >= 0;
     });
 
-    // No knowledge base tags selected
+    // No blog tags selected
     if (findblogTags.length === 0) {
       alert(app.translator.trans('v17development-flarum-blog.forum.composer.no_blog_tags_selected'));
       return;

--- a/js/src/forum/utils/extendTagOverview.js
+++ b/js/src/forum/utils/extendTagOverview.js
@@ -14,11 +14,13 @@ export default function extendTagOverview() {
     // Get blog tag ID's
     const blogTags = app.forum.attribute('blogTags') || [];
 
-    // Get tiles
-    let tag_tiles = markup.children[1].children[1].children[0].children;
+    const tag_tiles_parent = findChild(markup, 'TagsPage-content', true);
+    const tag_tiles = tag_tiles_parent?.children[0];
+
+    if (!tag_tiles_parent || !tag_tiles) return markup;
 
     // Map through the tiles and remove tiles that are part of the blog
-    markup.children[1].children[1].children[0].children = tag_tiles.map((tile, i) => {
+    tag_tiles.children = tag_tiles.children.map((tile, i) => {
       return blogTags.indexOf(this.tags[i].id()) >= 0 ? null : tile;
     });
 
@@ -36,4 +38,40 @@ export default function extendTagOverview() {
 
     return items;
   });
+}
+
+function findChild(parent, childClass, recursive = false) {
+  const children = getChildren(parent);
+  let child = null;
+
+  for (let i = 0; i < children.length; i++) {
+    const childClassName = children[i]?.attrs?.className || '';
+    if (childClassName.includes(childClass)) {
+      child = children[i];
+      break;
+    }
+  }
+
+  // Recursive search
+  if (recursive && !child) {
+    for (let subParent of children) {
+      const subChild = findChild(subParent, childClass, true);
+      if (subChild) {
+        return subChild;
+      }
+    }
+  }
+
+  return child;
+}
+
+function getChildren(parent) {
+  if (Array.isArray(parent)) {
+    return parent;
+  }
+  const children = parent?.children || [];
+  if (!Array.isArray(children)) {
+    return [];
+  }
+  return children;
 }

--- a/js/src/forum/utils/extendTagOverview.js
+++ b/js/src/forum/utils/extendTagOverview.js
@@ -11,15 +11,15 @@ export default function extendTagOverview() {
 
     if (app.forum.attribute('blogHideTags') == false) return markup;
 
-    // Get knowledge base tag ID's
-    const knowledgeBaseTags = app.forum.attribute('blogTags') || [];
+    // Get blog tag ID's
+    const blogTags = app.forum.attribute('blogTags') || [];
 
     // Get tiles
     let tag_tiles = markup.children[1].children[1].children[0].children;
 
-    // Map through the tiles and remove tiles that are part of the knowledge base
+    // Map through the tiles and remove tiles that are part of the blog
     markup.children[1].children[1].children[0].children = tag_tiles.map((tile, i) => {
-      return knowledgeBaseTags.indexOf(this.tags[i].id()) >= 0 ? null : tile;
+      return blogTags.indexOf(this.tags[i].id()) >= 0 ? null : tile;
     });
 
     return markup;

--- a/js/src/forum/utils/extendTagOverview.js
+++ b/js/src/forum/utils/extendTagOverview.js
@@ -40,7 +40,7 @@ export default function extendTagOverview() {
   });
 }
 
-function findChild(parent, childClass, recursive = false) {
+function findChild(parent, childClass, recursive = false, maxDepth = 50, depth = 0) {
   const children = getChildren(parent);
   let child = null;
 
@@ -53,9 +53,9 @@ function findChild(parent, childClass, recursive = false) {
   }
 
   // Recursive search
-  if (recursive && !child) {
+  if (recursive && !child && depth < maxDepth) {
     for (let subParent of children) {
-      const subChild = findChild(subParent, childClass, true);
+      const subChild = findChild(subParent, childClass, true, maxDepth, depth + 1);
       if (subChild) {
         return subChild;
       }


### PR DESCRIPTION
When the tags page UI is extended and customized, the current code that tries to manipulate the virtual DOM doing thing like 

```js
markup.children[1].children[1].children[0].children = tag_tiles.map(...
```

might break because the indexes of children have changed.

This PR adds a safer and more flexible way of manipulating the virtual DOM using a recursive helper function that searches for a node with a certain class name.

Tested locally on the instance that was failing and everything seems to be fine.

While making this PR I realized there was strange (seemingly copy-pasted) comments and code that was referring to "knowledge base" even though this is the blog extension and not the knowledge base extension.