### PR TITLE
fix: add v17development/flarum-seo as optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
       "optional-dependencies": [
         "flarum/sticky",
         "fof/discussion-language",
-        "askvortsov/flarum-rich-text"
+        "askvortsov/flarum-rich-text",
+        "v17development/flarum-seo"
       ]
     },
     "branch-alias": {


### PR DESCRIPTION
This fixes a bug were (sometimes) v17development/flarum-seo is not properly initialized when installed and enabled.

![image](https://github.com/v17development/flarum-blog/assets/146922689/7b973c06-3fad-4e19-8a9d-e7c8ebaea248)
