### PR TITLE
fix: blog composer crash with fof/rich-text enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "flarum/phpstan": "^1.0",
     "flarum/testing": "^1.0.0",
     "fof/discussion-language": "*",
+    "fof/rich-text": "^1.0",
     "fof/seo": "^3"
   },
   "replace": {

--- a/less/Forum/Composer.less
+++ b/less/Forum/Composer.less
@@ -67,8 +67,18 @@
   }
 
   &-HideEditor {
+    // Hide the editor while the preview tab is active WITHOUT `display: none`.
+    // ProseMirror (fof/rich-text) nulls its internal `docView` when its DOM node
+    // is removed from layout via `display: none`, which then crashes on the next
+    // toolbar command (`this.docView is null`). Keeping the node laid out but
+    // visually hidden and non-interactive avoids that while still hiding it.
     .TextEditor {
-      display: none;
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
## Problem

With `fof/rich-text` enabled, switching to the composer's **Preview** tab and then using a toolbar command crashed with:

```
Uncaught TypeError: can't access property "matchesNode", this.docView is null
```

## Cause

The preview tab hid the editor via `.TextEditor { display: none }`. ProseMirror nulls its internal `docView` when its DOM node is removed from layout, so the next dispatched transaction (e.g. a toolbar button) crashed. This was a pre-existing issue exposed by `fof/rich-text` (the maintained successor to the abandoned `askvortsov/flarum-rich-text`).

## Fix

- Hide the editor during preview via off-screen positioning instead of `display: none`, keeping the node in layout so `docView` stays valid.
- Add `fof/rich-text` as a dev dependency so the integration can be analysed/tested.

> Verified: phpstan, build, and the full test suite pass. Runtime behaviour with rich-text enabled should be confirmed in a browser.