### PR TITLE
fix: redirect trailing-slash blog URLs to canonical form

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -19,6 +19,7 @@ use Flarum\Discussion\Event\Saving;
 use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
+use Flarum\Http\Middleware\ResolveRoute;
 use Flarum\Tags\Api\Serializer\TagSerializer;
 use FoF\Blog\Access\ScopeDiscussionVisibility;
 use FoF\Blog\Api\AttachForumSerializerAttributes;
@@ -33,6 +34,7 @@ use FoF\Blog\Controller\BlogComposerController;
 use FoF\Blog\Controller\BlogItemController;
 use FoF\Blog\Controller\BlogOverviewController;
 use FoF\Blog\Listeners\CreateBlogMetaOnDiscussionCreate;
+use FoF\Blog\Middleware\RedirectTrailingSlash;
 use FoF\Blog\Query\BlogArticleFilterGambit;
 use FoF\Blog\Query\FilterDiscussionsForBlogPosts;
 use FoF\Blog\SeoPage\SeoBlogArticleMeta;
@@ -40,6 +42,10 @@ use FoF\Blog\SeoPage\SeoBlogOverviewMeta;
 use FoF\Blog\Subscribers\SeoBlogSubscriber;
 
 return [
+    // 1.x workaround for trailing slash. Not applicable to 2.x
+    (new Extend\Middleware('forum'))
+        ->insertBefore(ResolveRoute::class, RedirectTrailingSlash::class),
+
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/Forum.less')

--- a/src/Middleware/RedirectTrailingSlash.php
+++ b/src/Middleware/RedirectTrailingSlash.php
@@ -45,7 +45,7 @@ class RedirectTrailingSlash implements MiddlewareInterface
      */
     private function shouldRedirect(string $path): bool
     {
-        if ($path === '/' || ! str_ends_with($path, '/')) {
+        if ($path === '/' || !str_ends_with($path, '/')) {
             return false;
         }
 

--- a/src/Middleware/RedirectTrailingSlash.php
+++ b/src/Middleware/RedirectTrailingSlash.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Middleware;
+
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Blog frontend routes are registered without a trailing slash (e.g. `/blog`,
+ * `/blog/compose`). A trailing-slash variant (`/blog/`) does not match the
+ * Mithril route, so a direct load or refresh would 404. This middleware
+ * redirects any trailing-slash blog URL to its canonical, slash-less form.
+ */
+class RedirectTrailingSlash implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $uri = $request->getUri();
+        $path = $uri->getPath();
+
+        if ($this->shouldRedirect($path)) {
+            $canonical = rtrim($path, '/');
+
+            return new RedirectResponse((string) $uri->withPath($canonical), 301);
+        }
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * Only act on blog paths that have a trailing slash — never the site root,
+     * and never a bare `/` request.
+     */
+    private function shouldRedirect(string $path): bool
+    {
+        if ($path === '/' || ! str_ends_with($path, '/')) {
+            return false;
+        }
+
+        $trimmed = rtrim($path, '/');
+
+        return $trimmed === '/blog' || str_starts_with($trimmed, '/blog/');
+    }
+}

--- a/tests/integration/forum/TrailingSlashRedirectTest.php
+++ b/tests/integration/forum/TrailingSlashRedirectTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Tests\integration\forum;
+
+use Flarum\Testing\integration\TestCase;
+
+/**
+ * A trailing slash on a blog URL (e.g. `/blog/`) does not match the registered
+ * `/blog` frontend route, so a direct load or refresh 404s. Blog URLs with a
+ * trailing slash should redirect to their canonical, slash-less form.
+ */
+class TrailingSlashRedirectTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'fof-blog');
+    }
+
+    /**
+     * @test
+     */
+    public function blog_overview_with_trailing_slash_redirects_to_canonical(): void
+    {
+        $response = $this->send($this->request('GET', '/blog/'));
+
+        $this->assertSame(301, $response->getStatusCode(), 'Expected /blog/ to 301 redirect');
+        $this->assertSame('/blog', $this->redirectPath($response));
+    }
+
+    /**
+     * @test
+     */
+    public function blog_overview_without_trailing_slash_is_served_normally(): void
+    {
+        $response = $this->send($this->request('GET', '/blog'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * @test
+     */
+    public function nested_blog_path_with_trailing_slash_redirects(): void
+    {
+        $response = $this->send($this->request('GET', '/blog/compose/'));
+
+        $this->assertSame(301, $response->getStatusCode(), 'Expected /blog/compose/ to 301 redirect');
+        $this->assertSame('/blog/compose', $this->redirectPath($response));
+    }
+
+    /**
+     * @test
+     */
+    public function the_forum_root_is_not_affected(): void
+    {
+        $response = $this->send($this->request('GET', '/'));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    private function redirectPath(\Psr\Http\Message\ResponseInterface $response): string
+    {
+        $location = $response->getHeaderLine('Location');
+
+        return parse_url($location, PHP_URL_PATH) ?? $location;
+    }
+}


### PR DESCRIPTION
A trailing slash (e.g. `/blog/`) does not match the registered `/blog` frontend route, so a direct load or refresh returns a 404. Only navigating via in-app links worked.

Adds a forum middleware that 301-redirects trailing-slash blog URLs (`/blog/`, `/blog/compose/`, etc.) to their canonical slash-less form, inserted before route resolution so it applies before the router can 404.

Covered by `TrailingSlashRedirectTest`.