### PR TITLE
fix: use migrated fof-blog translation keys in SEO output

### DIFF
--- a/src/BlogMeta/Commands/UpdateBlogMetaHandler.php
+++ b/src/BlogMeta/Commands/UpdateBlogMetaHandler.php
@@ -75,7 +75,7 @@ class UpdateBlogMetaHandler
         if (empty($command->id) || !is_numeric($command->id)) {
             throw new ValidationException([
                 'message' => $this->translator->trans(
-                    'v17development-flarum-blog.forum.validation.missing_id'
+                    'fof-blog.forum.validation.missing_id'
                 ),
             ]);
         }

--- a/src/SeoPage/SeoBlogArticleMeta.php
+++ b/src/SeoPage/SeoBlogArticleMeta.php
@@ -91,7 +91,7 @@ class SeoBlogArticleMeta implements PageDriverInterface
             // Find discussion
             $discussion = $this->discussionRepository->findOrFail($discussionId);
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
-            $properties->setTitle($this->translator->trans('v17development-flarum-blog.forum.blog'));
+            $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
 
             // Do nothing, no model found
             return;
@@ -138,6 +138,6 @@ class SeoBlogArticleMeta implements PageDriverInterface
         $properties->setCanonicalUrl($fullArticleUrl, false);
 
         // Set blog article title
-        $properties->setTitle($seoMeta->title.' - '.$this->translator->trans('v17development-flarum-blog.forum.blog'));
+        $properties->setTitle($seoMeta->title.' - '.$this->translator->trans('fof-blog.forum.blog'));
     }
 }

--- a/src/SeoPage/SeoBlogOverviewMeta.php
+++ b/src/SeoPage/SeoBlogOverviewMeta.php
@@ -74,9 +74,9 @@ class SeoBlogOverviewMeta implements PageDriverInterface
         try {
             $category = Tag::where('slug', $category)->firstOrFail();
 
-            $properties->setTitle($this->translator->trans('v17development-flarum-blog.forum.blog'));
+            $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
-            $properties->setTitle($this->translator->trans('v17development-flarum-blog.forum.blog'));
+            $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
 
             // Do nothing, no model found
             return;
@@ -94,6 +94,6 @@ class SeoBlogOverviewMeta implements PageDriverInterface
         $properties->generateTagsFromMetaData($seoMeta);
 
         // Set blog title
-        $properties->setTitle($seoMeta->title.' - '.$this->translator->trans('v17development-flarum-blog.forum.blog'));
+        $properties->setTitle($seoMeta->title.' - '.$this->translator->trans('fof-blog.forum.blog'));
     }
 }

--- a/src/Subscribers/SeoBlogSubscriber.php
+++ b/src/Subscribers/SeoBlogSubscriber.php
@@ -26,6 +26,18 @@ use Illuminate\Contracts\Events\Dispatcher;
  */
 class SeoBlogSubscriber
 {
+    /**
+     * Identifier stamped on SeoMeta records whose Open Graph image this
+     * extension manages.
+     */
+    const OG_IMAGE_SOURCE = 'fof-blog';
+
+    /**
+     * The pre-migration identifier, still recognised for backwards
+     * compatibility with data created by v17development/flarum-blog.
+     */
+    const LEGACY_OG_IMAGE_SOURCE = 'v17development-flarum-blog';
+
     public function __construct(private SeoProperties $seoProperties)
     {
     }
@@ -157,10 +169,15 @@ class SeoBlogSubscriber
         // Set description
         $seoMeta->description = $blogMeta->summary;
 
-        // Only update image if source was set to auto and is not managed by a different extension
-        if (!$seoMeta->open_graph_image_source || $seoMeta->open_graph_image_source === 'auto' || $seoMeta->open_graph_image_source === 'v17development-flarum-blog') {
+        // Only update image if source was set to auto and is not managed by a
+        // different extension. The legacy `v17development-flarum-blog` source is
+        // still recognised so images stored before the FoF migration stay owned
+        // by this extension; new writes use the `fof-blog` source.
+        $ownedSources = ['auto', self::OG_IMAGE_SOURCE, self::LEGACY_OG_IMAGE_SOURCE];
+
+        if (!$seoMeta->open_graph_image_source || in_array($seoMeta->open_graph_image_source, $ownedSources, true)) {
             $seoMeta->open_graph_image = $blogMeta->featured_image;
-            $seoMeta->open_graph_image_source = 'v17development-flarum-blog';
+            $seoMeta->open_graph_image_source = self::OG_IMAGE_SOURCE;
         }
     }
 }

--- a/tests/integration/forum/SeoBlogTitleTest.php
+++ b/tests/integration/forum/SeoBlogTitleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Tests\integration\forum;
+
+use Flarum\Testing\integration\TestCase;
+
+/**
+ * The blog SEO page drivers must use the migrated `fof-blog.*` translation keys.
+ * Previously they referenced the old `v17development-flarum-blog.forum.blog`
+ * key, which no longer exists in the locale, so the literal key leaked into the
+ * rendered <title> / og:title / twitter:title.
+ */
+class SeoBlogTitleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'fof-seo', 'fof-blog');
+    }
+
+    protected function fetchHtml(string $path): string
+    {
+        $response = $this->send($this->request('GET', $path));
+
+        $this->assertEquals(200, $response->getStatusCode(), "Expected 200 from {$path}");
+
+        return (string) $response->getBody();
+    }
+
+    /**
+     * @test
+     */
+    public function blog_overview_title_does_not_leak_the_raw_translation_key(): void
+    {
+        $html = $this->fetchHtml('/blog');
+
+        $this->assertStringNotContainsString('v17development-flarum-blog', $html);
+    }
+
+    /**
+     * Translations are not loaded in the test environment, so the raw key is
+     * rendered verbatim. We assert the title references the migrated `fof-blog`
+     * key rather than the dead `v17development-flarum-blog` one.
+     *
+     * @test
+     */
+    public function blog_overview_title_uses_the_migrated_translation_key(): void
+    {
+        $html = $this->fetchHtml('/blog');
+
+        if (preg_match('/<title[^>]*>(.*?)<\/title>/is', $html, $m) === 1) {
+            $this->assertStringContainsString('fof-blog.forum.blog', $m[1]);
+        } else {
+            $this->fail('No <title> tag found in the blog overview HTML');
+        }
+    }
+}

--- a/tests/unit/SeoBlogSubscriberTest.php
+++ b/tests/unit/SeoBlogSubscriberTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Tests\unit;
+
+use Flarum\Testing\unit\TestCase;
+use FoF\Blog\Subscribers\SeoBlogSubscriber;
+
+class SeoBlogSubscriberTest extends TestCase
+{
+    /**
+     * New writes must stamp the migrated `fof-blog` Open Graph image source.
+     *
+     * @test
+     */
+    public function og_image_source_is_the_migrated_identifier(): void
+    {
+        $this->assertSame('fof-blog', SeoBlogSubscriber::OG_IMAGE_SOURCE);
+    }
+
+    /**
+     * The pre-migration identifier must stay recognised so images stored by
+     * v17development/flarum-blog remain owned by this extension.
+     *
+     * @test
+     */
+    public function legacy_og_image_source_is_preserved_for_back_compat(): void
+    {
+        $this->assertSame('v17development-flarum-blog', SeoBlogSubscriber::LEGACY_OG_IMAGE_SOURCE);
+    }
+}


### PR DESCRIPTION
The SEO page drivers still referenced the old `v17development-flarum-blog.forum.blog` translation key, which no longer exists in the locale. The raw key leaked into the rendered `<title>`, `og:title` and `twitter:title` on blog pages.

Updates the keys to `fof-blog.*` in the SEO drivers and the update-blog-meta validation message. Also stamps the Open Graph image source as `fof-blog` for new writes while still recognising the legacy `v17development-flarum-blog` source, so images stored before the migration stay owned by this extension.

Covered by `SeoBlogTitleTest` and `SeoBlogSubscriberTest`. Tests assert the correct key is referenced (translations are not loaded in the test environment); validated rendering `Blog` on dev.flarum.one.