### PR TITLE
fix: resolve SEO default blog image URL from the assets disk

### DIFF
--- a/src/SeoPage/SeoBlogArticleMeta.php
+++ b/src/SeoPage/SeoBlogArticleMeta.php
@@ -20,6 +20,8 @@ use FoF\Seo\Page\PageDriverInterface;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -49,6 +51,11 @@ class SeoBlogArticleMeta implements PageDriverInterface
     protected $settings;
 
     /**
+     * @var Cloud
+     */
+    protected $assetsDir;
+
+    /**
      * @param DiscussionRepository $discussionRepository
      * @param TranslatorInterface  $translator
      */
@@ -57,13 +64,18 @@ class SeoBlogArticleMeta implements PageDriverInterface
         UrlGenerator $urlGenerator,
         Dispatcher $events,
         TranslatorInterface $translator,
-        SettingsRepositoryInterface $settings
+        SettingsRepositoryInterface $settings,
+        Factory $filesystemFactory
     ) {
         $this->discussionRepository = $discussionRepository;
         $this->urlGenerator = $urlGenerator;
         $this->events = $events;
         $this->translator = $translator;
         $this->settings = $settings;
+
+        /** @var Cloud $assetsDir */
+        $assetsDir = $filesystemFactory->disk('flarum-assets');
+        $this->assetsDir = $assetsDir;
     }
 
     public function extensionDependencies(): array
@@ -127,9 +139,13 @@ class SeoBlogArticleMeta implements PageDriverInterface
         // Set schema JSON
         $properties->setSchemaJson('@type', 'BlogPosting');
 
-        // Set default featured image
-        if (!$seoMeta->open_graph_image && $this->settings->get('blog_default_image_path', null) !== null) {
-            $properties->setImage($this->urlGenerator->to('forum')->base().'/assets/'.$this->settings->get('blog_default_image_path', null));
+        // Set default featured image. Resolve the URL from the assets disk so a
+        // relocated/cloud disk (e.g. S3) is honoured, rather than assuming a
+        // local `/assets/` path.
+        $defaultImage = $this->settings->get('blog_default_image_path', null);
+
+        if (!$seoMeta->open_graph_image && $defaultImage !== null) {
+            $properties->setImage($this->assetsDir->url($defaultImage));
         }
 
         // Update knowledge base url

--- a/tests/integration/forum/SeoDefaultImageUrlTest.php
+++ b/tests/integration/forum/SeoDefaultImageUrlTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Tests\integration\forum;
+
+use Carbon\Carbon;
+use Flarum\Extend;
+use Flarum\Foundation\Paths;
+use Flarum\Http\UrlGenerator;
+use Flarum\Testing\integration\TestCase;
+
+/**
+ * The blog article SEO driver falls back to the configured default image when
+ * an article has no Open Graph image of its own. That URL must be resolved from
+ * the `flarum-assets` disk (so a relocated/cloud disk is honoured), not built
+ * by hardcoding `<base>/assets/<path>`.
+ *
+ * To prove the disk is actually consulted, the test points the `flarum-assets`
+ * disk at a distinct CDN URL — which a hardcoded `/assets/` path would never
+ * produce.
+ */
+class SeoDefaultImageUrlTest extends TestCase
+{
+    const CDN = 'https://cdn.example.com/assets';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'fof-seo', 'fof-blog');
+
+        // Relocate the assets disk to a CDN so its url() differs from the
+        // forum base + /assets path.
+        $this->extend(
+            (new Extend\Filesystem())
+                ->disk('flarum-assets', function (Paths $paths, UrlGenerator $url) {
+                    return [
+                        'root' => "$paths->public/assets",
+                        'url'  => self::CDN,
+                    ];
+                })
+        );
+
+        $now = Carbon::parse('2025-01-01 00:00:00');
+
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 1, 'username' => 'admin', 'email' => 'admin@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Article', 'slug' => 'article', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => $now],
+            ],
+            'blog_meta' => [
+                // No featured_image -> the article has no OG image of its own.
+                ['id' => 1, 'discussion_id' => 1, 'summary' => 'A summary.', 'is_featured' => 0, 'is_sized' => 0, 'is_pending_review' => 0],
+            ],
+        ]);
+
+        $this->setting('blog_default_image_path', 'blog-default-abc123.png');
+    }
+
+    protected function ogImage(string $html): ?string
+    {
+        if (preg_match('/<meta\s+property="og:image"\s+content="([^"]*)"/i', $html, $m) === 1) {
+            return html_entity_decode($m[1], ENT_QUOTES | ENT_HTML5);
+        }
+
+        return null;
+    }
+
+    /**
+     * @test
+     */
+    public function article_default_og_image_is_resolved_from_the_assets_disk(): void
+    {
+        $response = $this->send($this->request('GET', '/blog/1-article'));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $ogImage = $this->ogImage((string) $response->getBody());
+
+        // Must point at the (relocated) assets disk, not a hardcoded /assets/ path.
+        $this->assertSame(self::CDN.'/blog-default-abc123.png', $ogImage);
+    }
+}


### PR DESCRIPTION
The blog article SEO driver built the default Open Graph image URL by hardcoding `<base>/assets/<path>`, so a relocated or cloud assets disk (e.g. S3/CDN) would emit a wrong image URL.

Resolves the URL from the `flarum-assets` disk via `url()` instead, matching how the forum serializer (`blogDefaultImageUrl`) and the upload controller already work.

Both sides are covered by tests: the upload path (`DefaultBlogImageTest` — image stored on the disk) and the read path (`SeoDefaultImageUrlTest` — relocates the assets disk to a CDN and asserts `og:image` follows the disk rather than a hardcoded `/assets/` path).