### PR TITLE
fix: set canonical URL on the blog overview SEO page

### DIFF
--- a/src/SeoPage/SeoBlogOverviewMeta.php
+++ b/src/SeoPage/SeoBlogOverviewMeta.php
@@ -12,6 +12,7 @@
 namespace FoF\Blog\SeoPage;
 
 use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Http\UrlGenerator;
 use Flarum\Tags\Tag;
 use Flarum\Tags\TagRepository;
 use FoF\Seo\Page\PageDriverInterface;
@@ -37,6 +38,11 @@ class SeoBlogOverviewMeta implements PageDriverInterface
     protected $translator;
 
     /**
+     * @var UrlGenerator
+     */
+    protected $urlGenerator;
+
+    /**
      * @param TagRepository $tagRepository
      * @param Dispatcher    $events
      */
@@ -44,10 +50,12 @@ class SeoBlogOverviewMeta implements PageDriverInterface
         TagRepository $tagRepository,
         Dispatcher $events,
         TranslatorInterface $translator,
+        UrlGenerator $urlGenerator,
     ) {
         $this->tagRepository = $tagRepository;
         $this->events = $events;
         $this->translator = $translator;
+        $this->urlGenerator = $urlGenerator;
     }
 
     public function extensionDependencies(): array
@@ -68,17 +76,21 @@ class SeoBlogOverviewMeta implements PageDriverInterface
         ServerRequestInterface $request,
         SeoProperties $properties
     ): void {
+        $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
+
         // Get tag slug from params
-        $category = Arr::get($request->getQueryParams(), 'category');
+        $categorySlug = Arr::get($request->getQueryParams(), 'category');
 
         try {
-            $category = Tag::where('slug', $category)->firstOrFail();
-
-            $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
+            $category = Tag::where('slug', $categorySlug)->firstOrFail();
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
-            $properties->setTitle($this->translator->trans('fof-blog.forum.blog'));
+            // No category: this is the plain blog overview. Canonicalise it to
+            // the blog route so it does not fall back to core's default (e.g.
+            // `/all` when the blog overview is the forum home page).
+            $overviewUrl = $this->urlGenerator->to('forum')->route('blog.overview');
+            $properties->setUrl($overviewUrl, false);
+            $properties->setCanonicalUrl($overviewUrl, false);
 
-            // Do nothing, no model found
             return;
         }
 
@@ -92,6 +104,11 @@ class SeoBlogOverviewMeta implements PageDriverInterface
 
         // Generate data
         $properties->generateTagsFromMetaData($seoMeta);
+
+        // Canonicalise to the category route.
+        $categoryUrl = $this->urlGenerator->to('forum')->route('blog.category', ['category' => $category->slug]);
+        $properties->setUrl($categoryUrl, false);
+        $properties->setCanonicalUrl($categoryUrl, false);
 
         // Set blog title
         $properties->setTitle($seoMeta->title.' - '.$this->translator->trans('fof-blog.forum.blog'));

--- a/tests/integration/forum/SeoOverviewCanonicalTest.php
+++ b/tests/integration/forum/SeoOverviewCanonicalTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of fof/blog.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Blog\Tests\integration\forum;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\TestCase;
+
+/**
+ * The blog overview SEO driver must set a canonical URL pointing at the blog,
+ * otherwise (e.g. when the blog overview is the forum home page) the canonical
+ * falls back to core's default (`/all`). Issue #105.
+ */
+class SeoOverviewCanonicalTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'fof-seo', 'fof-blog');
+
+        $now = Carbon::parse('2025-01-01 00:00:00');
+
+        $this->prepareDatabase([
+            'tags' => [
+                ['id' => 1, 'name' => 'Blog', 'slug' => 'blog', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false],
+            ],
+        ]);
+
+        $this->setting('blog_tags', '1');
+    }
+
+    protected function canonical(string $html): ?string
+    {
+        if (preg_match('/<link\s+rel="canonical"\s+href="([^"]*)"/i', $html, $m) === 1) {
+            return html_entity_decode($m[1], ENT_QUOTES | ENT_HTML5);
+        }
+
+        return null;
+    }
+
+    /**
+     * @test
+     */
+    public function blog_overview_sets_a_canonical_pointing_at_the_blog(): void
+    {
+        $html = (string) $this->send($this->request('GET', '/blog'))->getBody();
+
+        $this->assertSame('http://localhost/blog', $this->canonical($html));
+    }
+
+    /**
+     * @test
+     */
+    public function blog_category_sets_a_canonical_pointing_at_the_category(): void
+    {
+        $html = (string) $this->send($this->request('GET', '/blog/category/blog'))->getBody();
+
+        $this->assertSame('http://localhost/blog/category/blog', $this->canonical($html));
+    }
+}


### PR DESCRIPTION
The blog overview SEO driver set no canonical URL — only the article driver did. As a result, when the blog overview is set as the forum home page, the canonical tag fell back to core's default (`/all`) instead of the blog URL.

Injects `UrlGenerator` into `SeoBlogOverviewMeta` and sets the canonical (and og:url) to the `blog.overview` route for the overview, and the `blog.category` route for a category page. The plain-overview case previously returned early before setting any metadata; the title is now always set too.

Covered by `SeoOverviewCanonicalTest`.

Fixes #105.