### PR TITLE
[2.x] fix: forward all arguments when overriding DiscussionPage.show()

### DIFF
--- a/js/src/forum/utils/redirector.ts
+++ b/js/src/forum/utils/redirector.ts
@@ -24,7 +24,7 @@ export default function (): void {
   });
 
   // Redirect discussion to blog article
-  override(DiscussionPage.prototype, 'show', function (this: DiscussionPage, original, discussion: Discussion) {
+  override(DiscussionPage.prototype, 'show', function (this: DiscussionPage, original, discussion: Discussion, ...rest: unknown[]) {
     const discussionRedirectEnabled =
       app.forum.attribute('blogRedirectsEnabled') === 'both' || app.forum.attribute('blogRedirectsEnabled') === 'discussions_only';
 
@@ -51,6 +51,10 @@ export default function (): void {
       }
     }
 
-    return original(discussion as unknown as Parameters<typeof original>[0]);
+    // Forward every argument: show() also receives the page of posts that
+    // core preloaded (embedded in the server-rendered document, or fetched in
+    // parallel with the discussion). Dropping it makes the post stream
+    // re-request posts core had already loaded.
+    return original(...([discussion, ...rest] as Parameters<typeof original>));
   });
 }


### PR DESCRIPTION
## Changes proposed in this pull request

The discussion→article redirector overrides `DiscussionPage.show()` and ends with:

```ts
return original(discussion as unknown as Parameters<typeof original>[0]);
```

That drops every argument after the first. `show()` also receives the page of posts core has already loaded — embedded in the server-rendered document on a cold load, or fetched alongside the discussion on in-app navigation — so a truncating override can cause the post stream to re-request posts it already had.

Now forwards everything:

```ts
return original(...([discussion, ...rest] as Parameters<typeof original>));
```

### Honest scope

**This is not a live regression fix.** Core stashes the preloaded window on the component precisely so that argument-dropping overrides can't lose it, and I verified that empirically: instrumenting core's `show()` and comparing this branch against `2.x` gives identical results (`argCount=2, postsLen=3`, same number of post requests). The value here is that a pass-through override shouldn't rely on core defending against it, and shouldn't quietly break if the signature grows — the variadic form is what any `override()` used as a pass-through should look like.

`BlogItem` was checked too and needs no change: it extracts the embedded posts from `article.payload.included` itself.

## Reviewers should focus on

- The `...rest: unknown[]` signature and the cast on the spread — TypeScript can't infer a variadic pass-through against `Parameters<typeof original>` without it.
- Verified: `yarn build` clean, `yarn check-typings` clean, and a live cold-load + in-app-navigation check on a forum with blog redirects enabled (`both`) shows no behaviour change.

## Confirmed

- [x] Frontend changes: typings check passes, built and verified live.